### PR TITLE
force json mimetype with json_encode

### DIFF
--- a/src/Lime/App.php
+++ b/src/Lime/App.php
@@ -1312,6 +1312,14 @@ class Response {
                 header('ETag: "'.md5($this->body).'"');
             }
 
+            if (is_array($this->body)) {
+                $output = json_encode($this->body);
+                $this->mime = "json";
+            }
+            else {
+                $output = $this->body;
+            }
+
             header('HTTP/1.0 '.$this->status.' '.App::$statusCodes[$this->status]);
             header('Content-type: '.App::$mimeTypes[$this->mime]);
 
@@ -1319,7 +1327,7 @@ class Response {
                 header($h);
             }
 
-            echo is_array($this->body) ? json_encode($this->body) : $this->body;
+            echo $output;
         }
     }
 }


### PR DESCRIPTION
when the result of a callback is an array, Lime json_encode() the body response.
this patch force the mimeType to "json" according to this response.